### PR TITLE
Add logic to skip schemes from Cartfile.ignore

### DIFF
--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		90CDE7BE2003252C00D98F37 /* FakeOSSSwift.framework in Resources */ = {isa = PBXBuildFile; fileRef = 90CDE7BC2003249C00D98F37 /* FakeOSSSwift.framework */; };
 		98400F5E1BD24DFA008C5DDE /* carthage-bash-completion in Copy Scripts */ = {isa = PBXBuildFile; fileRef = 98400F5A1BD24DC5008C5DDE /* carthage-bash-completion */; };
 		98400F5F1BD24DFA008C5DDE /* carthage-zsh-completion in Copy Scripts */ = {isa = PBXBuildFile; fileRef = 98400F5B1BD24DC5008C5DDE /* carthage-zsh-completion */; };
+		A12397B91F2AB3A600A4370F /* TestCartfile.ignore in Resources */ = {isa = PBXBuildFile; fileRef = A12397B71F2AB24900A4370F /* TestCartfile.ignore */; };
 		A1411ED61EFC1BFD0060461F /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1411ED51EFC1BFD0060461F /* Constants.swift */; };
 		B17145F11F43F812006DC662 /* NewResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17145EF1F43F797006DC662 /* NewResolver.swift */; };
 		A199B91C1EF2557300AE5933 /* Ignorefile.swift in Sources */ = {isa = PBXBuildFile; fileRef = A199B91B1EF2557300AE5933 /* Ignorefile.swift */; };
@@ -200,6 +201,7 @@
 		90CDE7BC2003249C00D98F37 /* FakeOSSSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = FakeOSSSwift.framework; sourceTree = "<group>"; };
 		98400F5A1BD24DC5008C5DDE /* carthage-bash-completion */ = {isa = PBXFileReference; lastKnownFileType = text; path = "carthage-bash-completion"; sourceTree = "<group>"; };
 		98400F5B1BD24DC5008C5DDE /* carthage-zsh-completion */ = {isa = PBXFileReference; lastKnownFileType = text; path = "carthage-zsh-completion"; sourceTree = "<group>"; };
+		A12397B71F2AB24900A4370F /* TestCartfile.ignore */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = TestCartfile.ignore; sourceTree = "<group>"; };
 		A1411ED51EFC1BFD0060461F /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		A14BB69B1EFA36B90077ABF4 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text; name = .swiftlint.yml; path = Tests/.swiftlint.yml; sourceTree = SOURCE_ROOT; };
 		B17145EF1F43F797006DC662 /* NewResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewResolver.swift; sourceTree = "<group>"; };
@@ -373,6 +375,7 @@
 				90CDE7BC2003249C00D98F37 /* FakeOSSSwift.framework */,
 				CD09E2881F0E3F1400A0378A /* FakeSwift.framework */,
 				D0AAAB5419FB1062007B24B3 /* TestCartfile */,
+				A12397B71F2AB24900A4370F /* TestCartfile.ignore */,
 				D0F551DB1A0D71AB0093311F /* TestCartfile.resolved */,
 				CDCE1CC21C170E8100B2ED88 /* TestResolvedCartfile.resolved */,
 				B1F27D3F1E4541A1002D4754 /* TestVersionFile */,
@@ -739,6 +742,7 @@
 				CD9A77991EDD7E2000A77B00 /* DuplicateDependencies in Resources */,
 				D0C6E5761A57042100A5E3E7 /* CartfilePrivateOnly.zip in Resources */,
 				CDCE1CC41C170E8A00B2ED88 /* TestResolvedCartfile.resolved in Resources */,
+				A12397B91F2AB3A600A4370F /* TestCartfile.ignore in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		06F5F0AD208C493200D528CD /* DependencyTestCartfile.ignore in Resources */ = {isa = PBXBuildFile; fileRef = 06F5F0AC208C493200D528CD /* DependencyTestCartfile.ignore */; };
+		06F5F0AE208C494A00D528CD /* DependencyTestCartfile.ignore in Resources */ = {isa = PBXBuildFile; fileRef = 06F5F0AC208C493200D528CD /* DependencyTestCartfile.ignore */; };
 		0FDFEA7E2055D638008862E3 /* ProxyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FDFEA7D2055D638008862E3 /* ProxyTests.swift */; };
 		0FDFEA802055FACE008862E3 /* Proxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FDFEA7F2055FACE008862E3 /* Proxy.swift */; };
 		2190FA981FD5B2F0008D8A79 /* OutdatedDependencies in Resources */ = {isa = PBXBuildFile; fileRef = 2190FA961FD5B05F008D8A79 /* OutdatedDependencies */; };
@@ -34,8 +36,8 @@
 		98400F5F1BD24DFA008C5DDE /* carthage-zsh-completion in Copy Scripts */ = {isa = PBXBuildFile; fileRef = 98400F5B1BD24DC5008C5DDE /* carthage-zsh-completion */; };
 		A12397B91F2AB3A600A4370F /* TestCartfile.ignore in Resources */ = {isa = PBXBuildFile; fileRef = A12397B71F2AB24900A4370F /* TestCartfile.ignore */; };
 		A1411ED61EFC1BFD0060461F /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1411ED51EFC1BFD0060461F /* Constants.swift */; };
-		B17145F11F43F812006DC662 /* NewResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17145EF1F43F797006DC662 /* NewResolver.swift */; };
 		A199B91C1EF2557300AE5933 /* Ignorefile.swift in Sources */ = {isa = PBXBuildFile; fileRef = A199B91B1EF2557300AE5933 /* Ignorefile.swift */; };
+		B17145F11F43F812006DC662 /* NewResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17145EF1F43F797006DC662 /* NewResolver.swift */; };
 		B1F27D3E1E45382B002D4754 /* VersionFileSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F27D3D1E45382B002D4754 /* VersionFileSpec.swift */; };
 		B1F27D401E4541A1002D4754 /* TestVersionFile in Resources */ = {isa = PBXBuildFile; fileRef = B1F27D3F1E4541A1002D4754 /* TestVersionFile */; };
 		BE02925B1E40363B004FB579 /* XCDBLD.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE02925A1E40363B004FB579 /* XCDBLD.framework */; };
@@ -175,6 +177,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		06F5F0AC208C493200D528CD /* DependencyTestCartfile.ignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = DependencyTestCartfile.ignore; sourceTree = "<group>"; };
 		0FDFEA7D2055D638008862E3 /* ProxyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyTests.swift; sourceTree = "<group>"; };
 		0FDFEA7F2055FACE008862E3 /* Proxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Proxy.swift; sourceTree = "<group>"; };
 		2190FA961FD5B05F008D8A79 /* OutdatedDependencies */ = {isa = PBXFileReference; lastKnownFileType = folder; path = OutdatedDependencies; sourceTree = "<group>"; };
@@ -204,8 +207,8 @@
 		A12397B71F2AB24900A4370F /* TestCartfile.ignore */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = TestCartfile.ignore; sourceTree = "<group>"; };
 		A1411ED51EFC1BFD0060461F /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		A14BB69B1EFA36B90077ABF4 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text; name = .swiftlint.yml; path = Tests/.swiftlint.yml; sourceTree = SOURCE_ROOT; };
-		B17145EF1F43F797006DC662 /* NewResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewResolver.swift; sourceTree = "<group>"; };
 		A199B91B1EF2557300AE5933 /* Ignorefile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Ignorefile.swift; sourceTree = "<group>"; };
+		B17145EF1F43F797006DC662 /* NewResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewResolver.swift; sourceTree = "<group>"; };
 		B1F27D3D1E45382B002D4754 /* VersionFileSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VersionFileSpec.swift; sourceTree = "<group>"; };
 		B1F27D3F1E4541A1002D4754 /* TestVersionFile */ = {isa = PBXFileReference; explicitFileType = text.json; fileEncoding = 4; path = TestVersionFile; sourceTree = "<group>"; };
 		BE0292481E403355004FB579 /* XCDBLDExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCDBLDExtensions.swift; sourceTree = "<group>"; };
@@ -380,6 +383,7 @@
 				CDCE1CC21C170E8100B2ED88 /* TestResolvedCartfile.resolved */,
 				B1F27D3F1E4541A1002D4754 /* TestVersionFile */,
 				BE624F471E1341E900EAEFC9 /* DuplicateDependenciesCartfile */,
+				06F5F0AC208C493200D528CD /* DependencyTestCartfile.ignore */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -728,6 +732,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				06F5F0AE208C494A00D528CD /* DependencyTestCartfile.ignore in Resources */,
 				8AC381451FC3AAE4007CF7E8 /* Alamofire.framework in Resources */,
 				CD9A779B1EDD7FEB00A77B00 /* BinaryOnly in Resources */,
 				3B19041E1E4CFE4A00A866AD /* FakeOldObjc.framework in Resources */,
@@ -750,6 +755,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				06F5F0AD208C493200D528CD /* DependencyTestCartfile.ignore in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		98400F5F1BD24DFA008C5DDE /* carthage-zsh-completion in Copy Scripts */ = {isa = PBXBuildFile; fileRef = 98400F5B1BD24DC5008C5DDE /* carthage-zsh-completion */; };
 		A1411ED61EFC1BFD0060461F /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1411ED51EFC1BFD0060461F /* Constants.swift */; };
 		B17145F11F43F812006DC662 /* NewResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17145EF1F43F797006DC662 /* NewResolver.swift */; };
+		A199B91C1EF2557300AE5933 /* Ignorefile.swift in Sources */ = {isa = PBXBuildFile; fileRef = A199B91B1EF2557300AE5933 /* Ignorefile.swift */; };
 		B1F27D3E1E45382B002D4754 /* VersionFileSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F27D3D1E45382B002D4754 /* VersionFileSpec.swift */; };
 		B1F27D401E4541A1002D4754 /* TestVersionFile in Resources */ = {isa = PBXBuildFile; fileRef = B1F27D3F1E4541A1002D4754 /* TestVersionFile */; };
 		BE02925B1E40363B004FB579 /* XCDBLD.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE02925A1E40363B004FB579 /* XCDBLD.framework */; };
@@ -202,6 +203,7 @@
 		A1411ED51EFC1BFD0060461F /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		A14BB69B1EFA36B90077ABF4 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text; name = .swiftlint.yml; path = Tests/.swiftlint.yml; sourceTree = SOURCE_ROOT; };
 		B17145EF1F43F797006DC662 /* NewResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewResolver.swift; sourceTree = "<group>"; };
+		A199B91B1EF2557300AE5933 /* Ignorefile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Ignorefile.swift; sourceTree = "<group>"; };
 		B1F27D3D1E45382B002D4754 /* VersionFileSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VersionFileSpec.swift; sourceTree = "<group>"; };
 		B1F27D3F1E4541A1002D4754 /* TestVersionFile */ = {isa = PBXFileReference; explicitFileType = text.json; fileEncoding = 4; path = TestVersionFile; sourceTree = "<group>"; };
 		BE0292481E403355004FB579 /* XCDBLDExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCDBLDExtensions.swift; sourceTree = "<group>"; };
@@ -516,6 +518,7 @@
 				88ED56D519ECE34900CBF5C4 /* Git.swift */,
 				D0D1219119E88B8F005E4BAA /* GitHub.swift */,
 				CD43D9DD1F43074000CD60F6 /* GitURL.swift */,
+				A199B91B1EF2557300AE5933 /* Ignorefile.swift */,
 				D0A2025D1B114D1000C71375 /* ProducerQueue.swift */,
 				CD28C99C1E11846200322AF7 /* ProductType.swift */,
 				F603929819EA29F80050A6AF /* Project.swift */,
@@ -834,6 +837,7 @@
 				D0DE89441A0F2D9B0030A3EC /* Scannable.swift in Sources */,
 				F162F3421D63D8A900809D7E /* VersionFile.swift in Sources */,
 				CDD7CF791F75ED88000E0EA5 /* Dependency.swift in Sources */,
+				A199B91C1EF2557300AE5933 /* Ignorefile.swift in Sources */,
 				BF7A1A0B1E3A7AE9008CBCC5 /* BinaryProject.swift in Sources */,
 				D01D82D71A10160700F0DD94 /* Resolver.swift in Sources */,
 				CDB099241E6DC2D40030B4A8 /* ScannableError.swift in Sources */,

--- a/Source/CarthageKit/Constants.swift
+++ b/Source/CarthageKit/Constants.swift
@@ -92,6 +92,9 @@ public struct Constants {
 		/// The relative path to a project's Cartfile.resolved.
 		public static let resolvedCartfilePath = "Cartfile.resolved"
 
+		/// The relative path to a project's Cartfile.ignore.
+		public static let ignoreCartfilePath = "Cartfile.ignore"
+
 		/// The text that needs to exist in a GitHub Release asset's name, for it to be
 		/// tried as a binary framework.
 		public static let binaryAssetPattern = ".framework"

--- a/Source/CarthageKit/Ignorefile.swift
+++ b/Source/CarthageKit/Ignorefile.swift
@@ -74,6 +74,11 @@ public struct Ignorefile {
 public struct IgnoreEntry {
 	public let project: String?
 	public let scheme: String
+
+	public init(project: String?, scheme: String) {
+		self.project = project
+		self.scheme = scheme
+	}
 }
 
 extension IgnoreEntry: Comparable {

--- a/Source/CarthageKit/Ignorefile.swift
+++ b/Source/CarthageKit/Ignorefile.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Result
+
+/// Represents a Cartfile.ignore, which is a specification of what projects
+/// and schemes should be ignored and therefore excluded from update/boostrap.
+public struct Ignorefile {
+	/// The project names listed in the Cartfile.ignore.
+	public var projects: [IgnoreEntry]
+
+	/// The scheme names listed in the Cartfile.ignore.
+	public var schemes: [IgnoreEntry]
+
+	/// Returns the location where Cartfile.ignore should exist within the
+	/// given directory.
+	public static func url(in directoryURL: URL) -> URL {
+		return directoryURL.appendingPathComponent("Cartfile.ignore")
+	}
+
+	/// Attempts to parse Cartfile.ignore information from a string.
+	public static func from(string: String) -> Result<Ignorefile, CarthageError> {
+		var projects: [IgnoreEntry] = []
+		var schemes: [IgnoreEntry] = []
+		var result: Result<(), CarthageError> = .success(())
+
+		let commentIndicator = "#"
+		string.enumerateLines { line, stop in
+			let scanner = Scanner(string: line)
+
+			if scanner.scanString(commentIndicator, into: nil) {
+				// Skip the rest of the line.
+				return
+			}
+
+			if scanner.isAtEnd {
+				// The line was all whitespace.
+				return
+			}
+
+			switch IgnoreEntry.from(scanner) {
+			case let .success(ignoreEntry):
+				switch ignoreEntry {
+				case .project:
+					projects.append(ignoreEntry)
+
+				case .scheme:
+					schemes.append(ignoreEntry)
+				}
+
+			case let .failure(error):
+				result = .failure(CarthageError(scannableError: error))
+				stop = true
+				return
+			}
+
+			if scanner.scanString(commentIndicator, into: nil) {
+				// Skip the rest of the line.
+				return
+			}
+
+			if !scanner.isAtEnd {
+				result = .failure(CarthageError.parseError(description: "unexpected trailing characters in line: \(line)"))
+				stop = true
+			}
+		}
+
+		return result.flatMap { _ in
+			return .success(Ignorefile(projects: projects, schemes: schemes))
+		}
+	}
+
+	/// Attempts to parse a Ignorefile from a file at a given URL.
+	public static func from(file ignorefileURL: URL) -> Result<Ignorefile, CarthageError> {
+		do {
+			let ignorefileContents = try String(contentsOf: ignorefileURL, encoding: .utf8)
+			return Ignorefile
+				.from(string: ignorefileContents)
+		} catch let error as NSError {
+			return .failure(CarthageError.readFailed(ignorefileURL, error))
+		}
+	}
+}
+
+/// Uniquely identifies an ignore entry that can be used for ignores.
+public enum IgnoreEntry {
+	/// A project to be ignored.
+	case project(String)
+
+	/// A scheme to be ignored.
+	case scheme(String)
+}
+
+extension IgnoreEntry: Comparable {
+	public static func == (_ lhs: IgnoreEntry, _ rhs: IgnoreEntry) -> Bool {
+		switch (lhs, rhs) {
+		case let (.project(left), .project(right)), let (.scheme(left), .scheme(right)),
+		     let (.project(left), .scheme(right)), let (.scheme(left), .project(right)):
+			return left.caseInsensitiveCompare(right) == .orderedSame
+		}
+	}
+
+	public static func < (_ lhs: IgnoreEntry, _ rhs: IgnoreEntry) -> Bool {
+		switch (lhs, rhs) {
+		case let (.project(left), .project(right)), let (.scheme(left), .scheme(right)),
+		     let (.project(left), .scheme(right)), let (.scheme(left), .project(right)):
+			return left.caseInsensitiveCompare(right) == .orderedAscending
+		}
+	}
+}
+
+extension IgnoreEntry: Hashable {
+	public var hashValue: Int {
+		switch self {
+		case let .project(name), let .scheme(name):
+			return name.hashValue
+		}
+	}
+}
+
+extension IgnoreEntry: Scannable {
+	/// Attempts to parse an IgnoreEntry.
+	public static func from(_ scanner: Scanner) -> Result<IgnoreEntry, ScannableError> {
+		let parser: (String) -> Result<IgnoreEntry, ScannableError>
+
+		if scanner.scanString("project", into: nil) {
+			parser = { name in
+				return .success(IgnoreEntry.project(name))
+			}
+		} else if scanner.scanString("scheme", into: nil) {
+			parser = { name in
+				return .success(IgnoreEntry.scheme(name))
+			}
+		} else {
+			return .failure(ScannableError(message: "unexpected ignore entry type", currentLine: scanner.currentLine))
+		}
+
+		if !scanner.scanString("\"", into: nil) {
+			return .failure(ScannableError(message: "expected string after ignore entry type", currentLine: scanner.currentLine))
+		}
+
+		var name: NSString?
+		if !scanner.scanUpTo("\"", into: &name) || !scanner.scanString("\"", into: nil) {
+			return .failure(ScannableError(message: "empty or unterminated string after ignore entry type", currentLine: scanner.currentLine))
+		}
+
+		if let name = name {
+			return parser(name as String)
+		} else {
+			return .failure(ScannableError(message: "empty string after dependency type", currentLine: scanner.currentLine))
+		}
+	}
+}
+
+extension IgnoreEntry: CustomStringConvertible {
+	public var description: String {
+		switch self {
+		case let .project(name):
+			return "project \"\(name)\""
+
+		case let .scheme(name):
+			return "scheme \"\(name)\""
+		}
+	}
+}

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -94,6 +94,11 @@ public final class Project { // swiftlint:disable:this type_body_length
 		return directoryURL.appendingPathComponent(Constants.Project.resolvedCartfilePath, isDirectory: false)
 	}
 
+	/// The file URL to the project's Cartfile.ignore.
+	public var ignorefileURL: URL {
+		return directoryURL.appendingPathComponent(Constants.Project.ignoreCartfilePath, isDirectory: false)
+	}
+
 	/// Whether to prefer HTTPS for cloning (vs. SSH).
 	public var preferHTTPS = true
 
@@ -195,6 +200,18 @@ public final class Project { // swiftlint:disable:this type_body_length
 			Result(attempt: { try String(contentsOf: self.resolvedCartfileURL, encoding: .utf8) })
 				.mapError { .readFailed(self.resolvedCartfileURL, $0) }
 				.flatMap(ResolvedCartfile.from)
+		}
+	}
+
+	/// Reads the project's Cartfile.ignore.
+	public func loadIgnorefile() -> SignalProducer<Ignorefile, CarthageError> {
+		return SignalProducer.attempt {
+			do {
+				let ignorefileContents = try String(contentsOf: self.ignorefileURL, encoding: .utf8)
+				return Ignorefile.from(string: ignorefileContents)
+			} catch let error as NSError {
+				return .failure(.readFailed(self.ignorefileURL, error))
+			}
 		}
 	}
 

--- a/Source/CarthageKit/Project.swift
+++ b/Source/CarthageKit/Project.swift
@@ -205,13 +205,10 @@ public final class Project { // swiftlint:disable:this type_body_length
 
 	/// Reads the project's Cartfile.ignore.
 	public func loadIgnorefile() -> SignalProducer<Ignorefile, CarthageError> {
-		return SignalProducer.attempt {
-			do {
-				let ignorefileContents = try String(contentsOf: self.ignorefileURL, encoding: .utf8)
-				return Ignorefile.from(string: ignorefileContents)
-			} catch let error as NSError {
-				return .failure(.readFailed(self.ignorefileURL, error))
-			}
+		return SignalProducer {
+			Result(attempt: { try String(contentsOf: self.ignorefileURL, encoding: .utf8) })
+				.mapError { .readFailed(self.ignorefileURL, $0) }
+				.flatMap(Ignorefile.from)
 		}
 	}
 

--- a/Source/XCDBLD/ProjectLocator.swift
+++ b/Source/XCDBLD/ProjectLocator.swift
@@ -29,6 +29,11 @@ public enum ProjectLocator {
 	public var level: Int {
 		return fileURL.pathComponents.count - 1
 	}
+
+	/// The name of the project or workspace.
+	public var name: String {
+		return fileURL.deletingPathExtension().lastPathComponent
+	}
 }
 
 extension ProjectLocator: Comparable {

--- a/Source/carthage/Archive.swift
+++ b/Source/carthage/Archive.swift
@@ -49,7 +49,7 @@ public struct ArchiveCommand: CommandProtocol {
 		} else {
 			let directoryURL = URL(fileURLWithPath: options.directoryPath, isDirectory: true)
 			frameworks = buildableSchemesInDirectory(directoryURL, withConfiguration: "Release")
-				.flatMap(.merge) { scheme, project -> SignalProducer<BuildSettings, CarthageError> in
+				.flatMap(.merge) { scheme, project, _ -> SignalProducer<BuildSettings, CarthageError> in
 					let buildArguments = BuildArguments(project: project, scheme: scheme, configuration: "Release")
 					return BuildSettings.load(with: buildArguments)
 				}

--- a/Source/carthage/Build.swift
+++ b/Source/carthage/Build.swift
@@ -94,8 +94,12 @@ public struct BuildCommand: CommandProtocol {
 							case let .standardError(data):
 								stderrHandle.write(data)
 
-							case let .success(project, scheme):
-								carthage.println(formatting.bullets + "Building scheme " + formatting.quote(scheme.name) + " in " + formatting.projectName(project.description))
+							case let .success(project, scheme, skip):
+								if skip {
+									carthage.println(formatting.bullets + "Ignoring scheme " + formatting.quote(scheme.name) + " in " + formatting.projectName(project.description))
+								} else {
+									carthage.println(formatting.bullets + "Building scheme " + formatting.quote(scheme.name) + " in " + formatting.projectName(project.description))
+								}
 							}
 						}
 					)

--- a/Tests/CarthageKitTests/CartfileSpec.swift
+++ b/Tests/CarthageKitTests/CartfileSpec.swift
@@ -53,6 +53,21 @@ class CartfileSpec: QuickSpec {
 			]
 		}
 
+		it("should parse a Cartfile.ignore") {
+			let testCartfileURL = Bundle(for: type(of: self)).url(forResource: "TestCartfile", withExtension: "ignore")!
+			let testCartfile = try! String(contentsOf: testCartfileURL, encoding: .utf8)
+
+			let result = Ignorefile.from(string: testCartfile)
+			expect(result.error).to(beNil())
+
+			let ignorefile = result.value!
+			expect(ignorefile.ignoreEntries) == [
+				IgnoreEntry(project: nil, scheme: "RxMoya"), IgnoreEntry(project: nil, scheme: "RxSwift"),
+				IgnoreEntry(project: nil, scheme: "ReactiveMoya"), IgnoreEntry(project: nil, scheme: "ReactiveSwift"),
+				IgnoreEntry(project: "project", scheme: "scheme")
+			]
+		}
+
 		it("should detect duplicate dependencies in a single Cartfile") {
 			let testCartfileURL = Bundle(for: type(of: self)).url(forResource: "DuplicateDependenciesCartfile", withExtension: "")!
 			let testCartfile = try! String(contentsOf: testCartfileURL, encoding: .utf8)

--- a/Tests/CarthageKitTests/ProjectSpec.swift
+++ b/Tests/CarthageKitTests/ProjectSpec.swift
@@ -16,7 +16,7 @@ class ProjectSpec: QuickSpec {
 			let directoryURL = Bundle(for: type(of: self)).url(forResource: "DependencyTest", withExtension: nil)!
 			let buildDirectoryURL = directoryURL.appendingPathComponent(Constants.binariesFolderPath)
 
-			func buildDependencyTest(platforms: Set<Platform> = [], cacheBuilds: Bool = true, dependenciesToBuild: [String]? = nil) -> [String] {
+			func buildDependencyies(platforms: Set<Platform> = [], cacheBuilds: Bool = true, dependenciesToBuild: [String]? = nil) -> [(String, Bool)] {
 				let project = Project(directoryURL: directoryURL)
 				let result = project.buildCheckedOutDependenciesWithOptions(BuildOptions(configuration: "Debug", platforms: platforms, cacheBuilds: cacheBuilds), dependenciesToBuild: dependenciesToBuild)
 					.ignoreTaskData()
@@ -26,16 +26,26 @@ class ProjectSpec: QuickSpec {
 						} else {
 							NSLog("Building scheme \"\(scheme)\" in \(project)")
 						}					})
-					.map { _, scheme, _ in scheme }
+					.map { _, scheme, skip in (scheme, skip) }
 					.collect()
 					.single()!
 				expect(result.error).to(beNil())
 
-				return result.value!.map { $0.name }
+				return result.value!.map { ($0.name, $1) }
 			}
 
+			func buildDependencyTest(platforms: Set<Platform> = [], cacheBuilds: Bool = true, dependenciesToBuild: [String]? = nil) -> [String] {
+				return buildDependencyies(platforms: platforms, cacheBuilds: cacheBuilds, dependenciesToBuild: dependenciesToBuild).map { $0.0 }
+			}
+			
+			func buildDependencyTestWithIgnored(platforms: Set<Platform> = [], cacheBuilds: Bool = true, dependenciesToBuild: [String]? = nil) -> [(String, Bool)] {
+				return buildDependencyies(platforms: platforms, cacheBuilds: cacheBuilds, dependenciesToBuild: dependenciesToBuild)
+			}
+			
 			beforeEach {
 				_ = try? FileManager.default.removeItem(at: buildDirectoryURL)
+				_ = try? FileManager.default.removeItem(at: directoryURL.appendingPathComponent("Cartfile.ignore"))
+
 				// Pre-fetch the repos so we have a cache for the given tags
 				let sourceRepoUrl = directoryURL.appendingPathComponent("SourceRepos")
 				for repo in ["TestFramework1", "TestFramework2", "TestFramework3"] {
@@ -54,6 +64,21 @@ class ProjectSpec: QuickSpec {
 				expect(result.filter { $0.contains("Mac") }) == macOSexpected
 				expect(result.filter { $0.contains("iOS") }) == iOSExpected
 				expect(Set(result)) == Set<String>(macOSexpected + iOSExpected)
+			}
+			
+			it("should skip frameworks while building frameworks") {
+				let ignoreCartfile = Bundle(for: type(of: self)).url(forResource: "DependencyTestCartfile", withExtension: ".ignore")!
+				_ = try? FileManager.default.copyItem(at: ignoreCartfile, to: directoryURL.appendingPathComponent("Cartfile.ignore"))
+
+				let macOSexpected = ["TestFramework3_Mac", "TestFramework2_Mac", "TestFramework1_Mac"]
+				let iOSExpected = ["TestFramework3_iOS", "TestFramework2_iOS"]
+				
+				let result = buildDependencyTestWithIgnored(platforms: [], cacheBuilds: false)
+				let filteredResults = result.filter { !$0.1 }.map { $0.0 }
+				
+				expect(filteredResults.filter { $0.contains("Mac") }) == macOSexpected
+				expect(filteredResults.filter { $0.contains("iOS") }) == iOSExpected
+				expect(Set(filteredResults)) == Set<String>(macOSexpected + iOSExpected)
 			}
 
 			it("should determine build order without repo cache") {

--- a/Tests/CarthageKitTests/ProjectSpec.swift
+++ b/Tests/CarthageKitTests/ProjectSpec.swift
@@ -20,10 +20,13 @@ class ProjectSpec: QuickSpec {
 				let project = Project(directoryURL: directoryURL)
 				let result = project.buildCheckedOutDependenciesWithOptions(BuildOptions(configuration: "Debug", platforms: platforms, cacheBuilds: cacheBuilds), dependenciesToBuild: dependenciesToBuild)
 					.ignoreTaskData()
-					.on(value: { project, scheme in
-						NSLog("Building scheme \"\(scheme)\" in \(project)")
-					})
-					.map { _, scheme in scheme }
+					.on(value: { project, scheme, skip in
+						if skip {
+							NSLog("Ignoring scheme \"\(scheme)\" in \(project)")
+						} else {
+							NSLog("Building scheme \"\(scheme)\" in \(project)")
+						}					})
+					.map { _, scheme, _ in scheme }
 					.collect()
 					.single()!
 				expect(result.error).to(beNil())

--- a/Tests/CarthageKitTests/Resources/DependencyTestCartfile.ignore
+++ b/Tests/CarthageKitTests/Resources/DependencyTestCartfile.ignore
@@ -1,0 +1,1 @@
+scheme "TestFramework1_iOS"

--- a/Tests/CarthageKitTests/Resources/TestCartfile.ignore
+++ b/Tests/CarthageKitTests/Resources/TestCartfile.ignore
@@ -1,0 +1,10 @@
+# Ignore RxSwift variant of Moya
+scheme "RxMoya"
+scheme "RxSwift"
+
+# Ignore ReactiveSwift variant of Moya
+scheme "ReactiveMoya"
+scheme "ReactiveSwift"
+
+# Ignore scheme within specific project
+scheme "project/scheme"


### PR DESCRIPTION
I took a stab at skipping the schemes defined in Cartfile.ignore. Let me know if this is what you had in mind when you created your pull request on the Carthage repo (https://github.com/Carthage/Carthage/pull/1990). I didn't want to hijack your work by creating a new pull request on the Carthage repo. Hope this helps getting the feature merged!

Oh ya. Most of these commits are due to a rebase with carthage's master branch.